### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,19 +22,19 @@
   },
   "homepage": "https://github.com/conc-at/wat",
   "dependencies": {
-    "debug": "^2.1.1",
-    "express": "^4.12.0",
-    "lodash": "^3.3.1",
-    "react": "^0.12.2",
-    "socket.io": "^1.3.4",
-    "socket.io-client": "^1.3.4"
+    "debug": "2.1.3",
+    "express": "4.13.2",
+    "lodash": "3.10.0",
+    "react": "0.12.2",
+    "socket.io": "1.3.6",
+    "socket.io-client": "1.3.6"
   },
   "devDependencies": {
-    "babel": "^4.5.4",
-    "babelify": "^5.0.3",
-    "browserify": "^9.0.3",
-    "standard": "*",
-    "watch-run": "^1.2.1"
+    "babel": "4.7.16",
+    "babelify": "5.0.5",
+    "browserify": "9.0.8",
+    "standard": "5.3.0",
+    "watch-run": "1.2.1"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:
