### PR TITLE
Updated babel to version 5.8.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "socket.io-client": "^1.3.4"
   },
   "devDependencies": {
-    "babel": "^4.5.4",
+    "babel": "5.8.23",
     "babelify": "^5.0.3",
     "browserify": "^9.0.3",
     "standard": "*",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!
