### PR TITLE
Updated browserify to version 11.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "babel": "^4.5.4",
     "babelify": "^5.0.3",
-    "browserify": "^9.0.3",
+    "browserify": "11.2.0",
     "standard": "*",
     "watch-run": "^1.2.1"
   },


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!
