### PR TITLE
Updated babelify to version 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "babel": "^4.5.4",
-    "babelify": "^5.0.3",
+    "babelify": "6.3.0",
     "browserify": "^9.0.3",
     "standard": "*",
     "watch-run": "^1.2.1"


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!
