### PR TITLE
Updated express to version 4.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/conc-at/wat",
   "dependencies": {
     "debug": "^2.1.1",
-    "express": "^4.12.0",
+    "express": "^4.13.3",
     "lodash": "^3.3.1",
     "react": "^0.12.2",
     "socket.io": "^1.3.4",


### PR DESCRIPTION
:rocket:

express just published version 4.13.3, so that’s now up to date in your `package.json`.

This new version is already included in your current version range, but we’re sending you this pull request so you can check whether express is following SemVer. In case your tests pass you can just close this pull request, but should they fail you have to get a fix out. You can use this branch to work on that.
