### PR TITLE
Update lodash to version 3.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "express": "^4.12.0",
-    "lodash": "^3.3.1",
+    "lodash": "^3.10.1",
     "react": "^0.12.2",
     "socket.io": "^1.3.4",
     "socket.io-client": "^1.3.4"


### PR DESCRIPTION
:rocket:

lodash just published version 3.10.1, so that’s now up to date in your `package.json`.

This new version is **already included in your current version range**, but we’re sending you this pull request so you can check whether lodash is following SemVer. In case your tests pass you can just _close this pull request_, but should they fail you have to get a fix out – and you can use this branch to work on it.
